### PR TITLE
Feat/scout 4.2 advanced filtering

### DIFF
--- a/src/modules/matches/dto/match.dto.ts
+++ b/src/modules/matches/dto/match.dto.ts
@@ -6,6 +6,11 @@ import { CompetitionBasicDataDto } from '../../competitions/dto/competition.dto'
 import { SeasonBasicDataDto } from '../../seasons/dto/season.dto';
 import { TeamBasicDataDto } from '../../teams/dto/team.dto';
 
+class Count {
+  notes: number;
+  reports: number;
+}
+
 export class MatchDto {
   @Expose()
   id: string;
@@ -57,6 +62,9 @@ export class MatchDto {
     }),
   )
   season: SeasonBasicDataDto;
+
+  @Expose()
+  _count: Count;
 }
 
 export class MatchBasicDataDto extends PickType(MatchDto, [

--- a/src/modules/matches/dto/matches-pagination-options.dto.ts
+++ b/src/modules/matches/dto/matches-pagination-options.dto.ts
@@ -11,6 +11,8 @@ enum MatchesSortBy {
   competition = 'competition',
   group = 'group',
   season = 'season',
+  reportsCount = 'reportsCount',
+  notesCount = 'notesCount',
 }
 
 export type MatchesSortByUnion = keyof typeof MatchesSortBy;

--- a/src/modules/notes/dto/find-all-notes.dto.ts
+++ b/src/modules/notes/dto/find-all-notes.dto.ts
@@ -1,6 +1,13 @@
 import { PickType } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
 
 import { IsCuid } from '../../../common/decorators/is-cuid.decorator';
 
@@ -20,6 +27,12 @@ export class FindAllNotesDto {
   @IsOptional()
   @IsCuid()
   matchId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? [value] : value))
+  @IsArray()
+  @IsCuid({ each: true })
+  competitionIds?: string[];
 
   @IsOptional()
   @Transform(({ value }) => parseInt(value))

--- a/src/modules/notes/dto/find-all-notes.dto.ts
+++ b/src/modules/notes/dto/find-all-notes.dto.ts
@@ -36,6 +36,20 @@ export class FindAllNotesDto {
   percentageRatingRangeEnd?: number;
 
   @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1950)
+  @Max(2050)
+  playerBornAfter?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1950)
+  @Max(2050)
+  playerBornBefore?: number;
+
+  @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   isLiked?: boolean;

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -114,6 +114,8 @@ export class NotesService {
       matchId,
       percentageRatingRangeStart,
       percentageRatingRangeEnd,
+      playerBornAfter,
+      playerBornBefore,
       isLiked,
     }: FindAllNotesDto,
     userId?: string,
@@ -165,6 +167,11 @@ export class NotesService {
                 { match: { awayTeam: { id: teamId } } },
                 { meta: { team: { id: teamId } } },
               ],
+            },
+            {
+              player: {
+                yearOfBirth: { gte: playerBornAfter, lte: playerBornBefore },
+              },
             },
           ],
         },

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -112,6 +112,7 @@ export class NotesService {
       positionId,
       teamId,
       matchId,
+      competitionIds,
       percentageRatingRangeStart,
       percentageRatingRangeEnd,
       playerBornAfter,
@@ -154,6 +155,12 @@ export class NotesService {
             lte: percentageRatingRangeEnd,
           },
           likes: isLiked ? { some: { userId } } : undefined,
+          meta:
+            competitionIds && competitionIds.length > 0
+              ? {
+                  competition: { id: { in: competitionIds } },
+                }
+              : undefined,
           AND: [
             {
               OR: [

--- a/src/modules/players/dto/find-all-players.dto.ts
+++ b/src/modules/players/dto/find-all-players.dto.ts
@@ -57,6 +57,12 @@ export class FindAllPlayersDto {
   teamIds?: string[];
 
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? [value] : value))
+  @IsArray()
+  @IsCuid({ each: true })
+  competitionIds?: string[];
+
+  @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   isLiked?: boolean;

--- a/src/modules/players/dto/player.dto.ts
+++ b/src/modules/players/dto/player.dto.ts
@@ -7,6 +7,11 @@ import { LikePlayerBasicDataDto } from '../../like-players/dto/like-player.dto';
 import { PlayerPositionDto } from '../../player-positions/dto/player-position.dto';
 import { TeamAffiliationWithoutPlayerDto } from '../../team-affiliations/dto/team-affiliation.dto';
 
+class Count {
+  notes: number;
+  reports: number;
+}
+
 export class PlayerDto {
   @Expose()
   id: string;
@@ -92,6 +97,9 @@ export class PlayerDto {
   )
   @Expose()
   likes: LikePlayerBasicDataDto[];
+
+  @Expose()
+  _count: Count;
 }
 
 export class PlayerBasicDataDto extends PickType(PlayerDto, [

--- a/src/modules/players/dto/players-pagination-options.dto.ts
+++ b/src/modules/players/dto/players-pagination-options.dto.ts
@@ -13,6 +13,8 @@ enum PlayersSortBy {
   footed = 'footed',
   country = 'country',
   primaryPosition = 'primaryPosition',
+  reportsCount = 'reportsCount',
+  notesCount = 'notesCount',
 }
 
 export type PlayersSortByUnion = keyof typeof PlayersSortBy;

--- a/src/modules/players/players.service.ts
+++ b/src/modules/players/players.service.ts
@@ -21,6 +21,7 @@ const include: Prisma.PlayerInclude = {
       team: true,
     },
   },
+  _count: { select: { notes: true, reports: true } },
 };
 
 const listInclude: Prisma.PlayerInclude = {
@@ -45,6 +46,7 @@ const singleInclude = Prisma.validator<Prisma.PlayerInclude>()({
       },
     },
   },
+  _count: { select: { notes: true, reports: true } },
 });
 
 @Injectable()
@@ -110,6 +112,14 @@ export class PlayersService {
       case 'country':
       case 'primaryPosition':
         sort = { [sortBy]: { name: sortingOrder } };
+        break;
+
+      case 'reportsCount':
+        sort = { reports: { _count: sortingOrder } };
+        break;
+
+      case 'notesCount':
+        sort = { notes: { _count: sortingOrder } };
         break;
 
       default:

--- a/src/modules/reports/dto/find-all-reports.dto.ts
+++ b/src/modules/reports/dto/find-all-reports.dto.ts
@@ -36,6 +36,12 @@ export class FindAllReportsDto {
   teamIds?: string[];
 
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? [value] : value))
+  @IsArray()
+  @IsCuid({ each: true })
+  competitionIds?: string[];
+
+  @IsOptional()
   @Transform(({ value }) => parseInt(value))
   @IsInt()
   @Min(0)

--- a/src/modules/reports/dto/find-all-reports.dto.ts
+++ b/src/modules/reports/dto/find-all-reports.dto.ts
@@ -50,6 +50,20 @@ export class FindAllReportsDto {
   percentageRatingRangeEnd?: number;
 
   @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1950)
+  @Max(2050)
+  playerBornAfter?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1950)
+  @Max(2050)
+  playerBornBefore?: number;
+
+  @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   isLiked?: boolean;

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -162,6 +162,8 @@ export class ReportsService {
       teamIds,
       percentageRatingRangeStart,
       percentageRatingRangeEnd,
+      playerBornAfter,
+      playerBornBefore,
       isLiked,
     }: FindAllReportsDto,
     userId?: string,
@@ -198,6 +200,11 @@ export class ReportsService {
                 { meta: { position: { id: { in: positionIds } } } },
                 { player: { primaryPosition: { id: { in: positionIds } } } },
               ],
+            },
+            {
+              player: {
+                yearOfBirth: { gte: playerBornAfter, lte: playerBornBefore },
+              },
             },
             {
               OR: [

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -160,6 +160,7 @@ export class ReportsService {
       positionIds,
       matchIds,
       teamIds,
+      competitionIds,
       percentageRatingRangeStart,
       percentageRatingRangeEnd,
       playerBornAfter,
@@ -194,6 +195,12 @@ export class ReportsService {
             lte: percentageRatingRangeEnd,
           },
           likes: isLiked ? { some: { userId } } : undefined,
+          meta:
+            competitionIds && competitionIds.length > 0
+              ? {
+                  competition: { id: { in: competitionIds } },
+                }
+              : undefined,
           AND: [
             {
               OR: [


### PR DESCRIPTION
### Task Description

- add filtering players by competition
- add filtering notes & reports by players' year of birth
- add reports & notes filtering by competition
- add players & matches sorting by reports & notes count

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
