### PR TITLE
feat: add get one by slug endpoints

### DIFF
--- a/src/modules/clubs/clubs.controller.ts
+++ b/src/modules/clubs/clubs.controller.ts
@@ -93,6 +93,18 @@ export class ClubsController {
     return formatSuccessResponse(message, club);
   }
 
+  @Get('by-slug/:slug')
+  @ApiResponse(ClubDto, { type: 'read' })
+  @Serialize(ClubDto)
+  async findOneBySlug(@I18nLang() lang: string, @Param('slug') slug: string) {
+    const club = await this.clubsService.findOneBySlug(slug);
+    const message = this.i18n.translate('clubs.GET_ONE_MESSAGE', {
+      lang,
+      args: { name: club.name },
+    });
+    return formatSuccessResponse(message, club);
+  }
+
   @Patch(':id')
   @ApiResponse(ClubDto, { type: 'update' })
   @Serialize(ClubDto)

--- a/src/modules/clubs/clubs.service.ts
+++ b/src/modules/clubs/clubs.service.ts
@@ -86,6 +86,10 @@ export class ClubsService {
     return this.prisma.club.findUnique({ where: { id }, include });
   }
 
+  findOneBySlug(slug: string) {
+    return this.prisma.club.findUnique({ where: { slug }, include });
+  }
+
   findAllBySlug(slug: string) {
     return this.prisma.club.findMany({ where: { slug } });
   }

--- a/src/modules/competition-groups/competition-groups.controller.ts
+++ b/src/modules/competition-groups/competition-groups.controller.ts
@@ -16,7 +16,10 @@ import { AuthGuard } from '../../common/guards/auth.guard';
 import { Serialize } from '../../common/interceptors/serialize.interceptor';
 import { formatSuccessResponse } from '../../utils/helpers';
 import { CompetitionGroupsService } from './competition-groups.service';
-import { CompetitionGroupDto } from './dto/competition-group.dto';
+import {
+  CompetitionGroupBasicDataDto,
+  CompetitionGroupDto,
+} from './dto/competition-group.dto';
 import { CreateCompetitionGroupDto } from './dto/create-competition-group.dto';
 import { UpdateCompetitionGroupDto } from './dto/update-competition-group.dto';
 
@@ -24,7 +27,6 @@ import { UpdateCompetitionGroupDto } from './dto/update-competition-group.dto';
 @ApiTags('competition groups')
 @UseGuards(AuthGuard)
 @ApiCookieAuth()
-@Serialize(CompetitionGroupDto)
 export class CompetitionGroupsController {
   constructor(
     private readonly groupsService: CompetitionGroupsService,
@@ -33,6 +35,7 @@ export class CompetitionGroupsController {
 
   @Post()
   @ApiResponse(CompetitionGroupDto, { type: 'create' })
+  @Serialize(CompetitionGroupDto)
   async create(
     @I18nLang() lang: string,
     @Body() createCompetitionGroupDto: CreateCompetitionGroupDto,
@@ -45,8 +48,9 @@ export class CompetitionGroupsController {
     return formatSuccessResponse(message, group);
   }
 
-  @Get()
-  @ApiResponse(CompetitionGroupDto, { type: 'read', isArray: true })
+  @Get('list')
+  @ApiResponse(CompetitionGroupBasicDataDto, { type: 'read', isArray: true })
+  @Serialize(CompetitionGroupBasicDataDto)
   async findAll(@I18nLang() lang: string) {
     const groups = await this.groupsService.findAll();
     const message = this.i18n.translate('competition-groups.GET_ALL_MESSAGE', {
@@ -57,6 +61,7 @@ export class CompetitionGroupsController {
 
   @Get(':id')
   @ApiResponse(CompetitionGroupDto, { type: 'read' })
+  @Serialize(CompetitionGroupDto)
   async findOne(@I18nLang() lang: string, @Param('id') id: string) {
     const group = await this.groupsService.findOne(id);
     const message = this.i18n.translate('competition-groups.GET_ONE_MESSAGE', {
@@ -68,6 +73,7 @@ export class CompetitionGroupsController {
 
   @Patch(':id')
   @ApiResponse(CompetitionGroupDto, { type: 'update' })
+  @Serialize(CompetitionGroupDto)
   async update(
     @I18nLang() lang: string,
     @Param('id') id: string,
@@ -86,6 +92,7 @@ export class CompetitionGroupsController {
 
   @Delete(':id')
   @ApiResponse(CompetitionGroupDto, { type: 'delete' })
+  @Serialize(CompetitionGroupDto)
   async remove(@I18nLang() lang: string, @Param('id') id: string) {
     const group = await this.groupsService.remove(id);
     const message = this.i18n.translate('competition-groups.DELETE_MESSAGE', {

--- a/src/modules/competition-groups/competition-groups.service.ts
+++ b/src/modules/competition-groups/competition-groups.service.ts
@@ -6,7 +6,7 @@ import { CreateCompetitionGroupDto } from './dto/create-competition-group.dto';
 import { UpdateCompetitionGroupDto } from './dto/update-competition-group.dto';
 
 const include: Prisma.CompetitionGroupInclude = {
-  competition: true,
+  competition: { include: { country: true } },
   regions: { include: { region: true } },
 };
 

--- a/src/modules/players/players.controller.ts
+++ b/src/modules/players/players.controller.ts
@@ -117,6 +117,23 @@ export class PlayersController {
     return formatSuccessResponse(message, player);
   }
 
+  @Get('by-slug/:slug')
+  @UseGuards(ReadGuard)
+  @ApiResponse(PlayerDto, { type: 'read' })
+  @Serialize(PlayerDto)
+  async findOneBySlug(
+    @I18nLang() lang: string,
+    @Param('slug') slug: string,
+    @CurrentUser() user: CurrentUserDto,
+  ) {
+    const player = await this.playersService.findOneBySlug(slug, user.id);
+    const message = this.i18n.translate('players.GET_ONE_MESSAGE', {
+      lang,
+      args: { name: `${player.firstName} ${player.lastName}` },
+    });
+    return formatSuccessResponse(message, player);
+  }
+
   @Patch(':id')
   @UseGuards(UpdateGuard)
   @ApiResponse(PlayerDto, { type: 'update' })

--- a/src/modules/teams/teams.controller.ts
+++ b/src/modules/teams/teams.controller.ts
@@ -105,6 +105,22 @@ export class TeamsController {
     return formatSuccessResponse(message, team);
   }
 
+  @Get('by-slug/:slug')
+  @ApiResponse(TeamDto, { type: 'read' })
+  @Serialize(TeamDto)
+  async findOneBySlug(
+    @I18nLang() lang: string,
+    @Param('slug') slug: string,
+    @CurrentUser() user: CurrentUserDto,
+  ) {
+    const team = await this.teamsService.findOneBySlug(slug, user.id);
+    const message = this.i18n.translate('teams.GET_ONE_MESSAGE', {
+      lang,
+      args: { name: team.name },
+    });
+    return formatSuccessResponse(message, team);
+  }
+
   @Patch(':id')
   @ApiResponse(TeamDto, { type: 'update' })
   @Serialize(TeamDto)

--- a/src/modules/teams/teams.service.ts
+++ b/src/modules/teams/teams.service.ts
@@ -161,6 +161,20 @@ export class TeamsService {
     });
   }
 
+  findOneBySlug(slug: string, userId?: string) {
+    return this.prisma.team.findUnique({
+      where: { slug },
+      include: userId
+        ? {
+            ...include,
+            likes: {
+              where: { userId },
+            },
+          }
+        : include,
+    });
+  }
+
   findAllBySlug(slug: string) {
     return this.prisma.team.findMany({ where: { slug } });
   }


### PR DESCRIPTION
### Task Description

Add `by-slug` endpoints for clubs, teams & players modules

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
